### PR TITLE
Change to serialize as HTML instead of XML

### DIFF
--- a/packages/rehype-dom-stringify/lib/index.js
+++ b/packages/rehype-dom-stringify/lib/index.js
@@ -45,19 +45,8 @@ function serialize(node) {
     return '<DOCTYPE html>'
   }
 
-  // Element.
-  if ('outerHTML' in node) {
-    return node.outerHTML
-  }
-
-  // Comment, text, fragment.
-  if ('textContent' in node) {
-    const div = document.createElement('div')
-    div.append(node)
-    return div.innerHTML
-    /* c8 ignore next 4 */
-  }
-
-  // ?
-  return ''
+  // Comment, element, fragment, text.
+  const template = document.createElement('template')
+  template.content.append(node)
+  return template.innerHTML
 }

--- a/packages/rehype-dom-stringify/package.json
+++ b/packages/rehype-dom-stringify/package.json
@@ -36,8 +36,7 @@
     "@types/hast": "^2.0.0",
     "@types/web": "^0.0.99",
     "hast-util-to-dom": "^3.0.0",
-    "unified": "^10.0.0",
-    "web-namespaces": "^2.0.0"
+    "unified": "^10.0.0"
   },
   "scripts": {},
   "xo": false,

--- a/test.js
+++ b/test.js
@@ -92,7 +92,7 @@ test('parse', async (t) => {
         .data('settings', {fragment: false})
         .processSync('<title>Hi</title><h2>Hello world!')
         .toString(),
-      '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Hi</title></head><body><h2>Hello world!</h2></body></html>',
+      '<html><head><title>Hi</title></head><body><h2>Hello world!</h2></body></html>',
       'should stringify a complete document'
     )
 
@@ -101,13 +101,13 @@ test('parse', async (t) => {
         .data('settings', {fragment: false})
         .processSync('<!doctype html>')
         .toString(),
-      '<DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml"><head></head><body></body></html>',
+      '<DOCTYPE html><html><head></head><body></body></html>',
       'should stringify a doctype'
     )
 
     assert.equal(
       processor().processSync('<!doctype html>').toString(),
-      '<DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml"><head></head><body></body></html>',
+      '<DOCTYPE html><html><head></head><body></body></html>',
       'should support empty documents'
     )
 
@@ -184,7 +184,7 @@ test('parse', async (t) => {
         .data('settings', {fragment: false})
         .processSync('<title>Hi</title><h2>Hello world!')
         .toString(),
-      '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Hi</title></head><body><h2>Hello world!</h2></body></html>',
+      '<html><head><title>Hi</title></head><body><h2>Hello world!</h2></body></html>',
       'should parse a complete document'
     )
 

--- a/test.js
+++ b/test.js
@@ -16,7 +16,6 @@ import {rehypeDom} from 'rehype-dom'
 const {window} = new JSDOM('')
 
 // The globals needed by `rehype-dom`.
-global.XMLSerializer = window.XMLSerializer
 global.document = window.document
 global.DOMParser = window.DOMParser
 

--- a/test.js
+++ b/test.js
@@ -93,8 +93,23 @@ test('parse', async (t) => {
         .data('settings', {fragment: false})
         .processSync('<title>Hi</title><h2>Hello world!')
         .toString(),
-      '<html><head><title>Hi</title></head><body><h2>Hello world!</h2></body></html>',
+      '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Hi</title></head><body><h2>Hello world!</h2></body></html>',
       'should stringify a complete document'
+    )
+
+    assert.equal(
+      processor()
+        .data('settings', {fragment: false})
+        .processSync('<!doctype html>')
+        .toString(),
+      '<DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml"><head></head><body></body></html>',
+      'should stringify a doctype'
+    )
+
+    assert.equal(
+      processor().processSync('<!doctype html>').toString(),
+      '<DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml"><head></head><body></body></html>',
+      'should support empty documents'
     )
 
     assert.equal(
@@ -119,7 +134,7 @@ test('parse', async (t) => {
       processor()
         .use(rehypeDomStringify, {namespace: 'http://www.w3.org/2000/svg'})
         .stringify(u('root', [s('#foo.bar', s('circle'))])),
-      '<g xmlns="http://www.w3.org/2000/svg" id="foo" class="bar"><circle/></g>',
+      '<g id="foo" class="bar"><circle></circle></g>',
       'should support SVG'
     )
 
@@ -135,7 +150,7 @@ test('parse', async (t) => {
             ])
           ])
         ),
-      '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div>Alpha</div></foreignObject></svg>',
+      '<svg><foreignObject><div xmlns="http://www.w3.org/1999/xhtml">Alpha</div></foreignObject></svg>',
       'should support HTML in SVG'
     )
 
@@ -151,7 +166,7 @@ test('parse', async (t) => {
           ])
         ])
       ),
-      '<div><svg xmlns="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg"><foreignObject><div>Alpha</div></foreignObject></svg></div>',
+      '<div><svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div xmlns="http://www.w3.org/1999/xhtml">Alpha</div></foreignObject></svg></div>',
       'should support HTML in SVG in HTML'
     )
 
@@ -159,7 +174,7 @@ test('parse', async (t) => {
       processor()
         .use(rehypeDomStringify, {namespace: 'https://example.com'})
         .stringify(u('root', [h('example', 'Alpha')])),
-      '<example xmlns="https://example.com">Alpha</example>',
+      '<example>Alpha</example>',
       'should stringify namespaced elements'
     )
   })
@@ -170,7 +185,7 @@ test('parse', async (t) => {
         .data('settings', {fragment: false})
         .processSync('<title>Hi</title><h2>Hello world!')
         .toString(),
-      '<html><head><title>Hi</title></head><body><h2>Hello world!</h2></body></html>',
+      '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Hi</title></head><body><h2>Hello world!</h2></body></html>',
       'should parse a complete document'
     )
 
@@ -194,7 +209,7 @@ test('parse', async (t) => {
 
     assert.equal(
       rehypeDom().processSync('<input type="checkbox" checked />').toString(),
-      '<input type="checkbox" checked="" />',
+      '<input type="checkbox" checked="">',
       'should support boolean attributes'
     )
 
@@ -213,11 +228,27 @@ test('parse', async (t) => {
   </svg>`
         )
         .toString(),
-      `<svg xmlns="http://www.w3.org/2000/svg" width="230" height="120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <circle cx="60" cy="60" r="50" fill="red"/>
-    <circle cx="170" cy="60" r="50" fill="green"/>
+      `<svg width="230" height="120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <circle cx="60" cy="60" r="50" fill="red"></circle>
+    <circle cx="170" cy="60" r="50" fill="green"></circle>
   </svg>`,
       'should support svg'
+    )
+
+    assert.equal(
+      String(
+        rehypeDom().processSync(`<style>
+  body > style {
+    width: 100px;
+  }
+</style>`)
+      ),
+      `<style>
+  body > style {
+    width: 100px;
+  }
+</style>`,
+      'should process text in `style` correctly'
     )
 
     assert.equal(


### PR DESCRIPTION
Closes GH-21.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

This switches from the DOMs `XMLSerializer` to manually using DOM node’s APIs to serialize as HTML.
That is because the XML syntax is not always compatible with the HTML syntax.
However, it is a significant, breaking, change.

Closes GH-21.

<!--do not edit: pr-->
