### PR TITLE
Fix empty fragment string

### DIFF
--- a/packages/rehype-dom-stringify/lib/index.js
+++ b/packages/rehype-dom-stringify/lib/index.js
@@ -44,7 +44,7 @@ function serialize(node) {
   // Document.
   if ('doctype' in node) {
     const doctype = node.doctype ? serialize(node.doctype) : ''
-    const docelem = serialize(node.documentElement)
+    const docelem = node.documentElement ? serialize(node.documentElement) : ''
     return doctype + docelem
   }
 

--- a/test.js
+++ b/test.js
@@ -125,6 +125,16 @@ test('rehype-dom-stringify', async function (t) {
     )
   })
 
+  await t.test('should support empty fragment', async function () {
+    assert.equal(
+      processor()
+        .data('settings', {fragment: true})
+        .processSync('')
+        .toString(),
+      ''
+    )
+  })
+
   await t.test('should stringify a fragment', async function () {
     assert.equal(
       processor()


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Arehypejs&type=issues and https://github.com/orgs/rehypejs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

I've come to an error trying to stringify an empty string when `fragment: true` is enabled.
It fails [here](https://github.com/rehypejs/rehype-dom/pull/26/files#diff-9412939c832f52e62587ae195f999eb56cb41fc8f3d87c04367df4dc527f2e30L47) because `hast-util-to-dom` returns an `XmlDocument` with `documentElement: null`. So there is 2 solutions to me, either :
1. Handle the `XmlDocument` with `documenElement: null` in `rehype-dom-stringify`
2. Or, always return a `DocumentFragment` in `hast-util-to-dom` even if there is no child nodes

I have done solution 1 in this PR along with a failing test. If it you think solution 2 is more appropriate, I can make a PR to `hast-util-to-dom`.

<!--do not edit: pr-->
